### PR TITLE
Translations on the main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Translation for main page title
+- Translation for "Show only differences" button
 
 ## [0.5.0] - 2020-11-19
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.main-page.title": "Compare {productsLength} products",
   "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"

--- a/messages/context.json
+++ b/messages/context.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.main-page.title": "Compare {productsLength} products",
   "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"

--- a/messages/en.json
+++ b/messages/en.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.main-page.title": "Compare {productsLength} products",
   "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"

--- a/messages/es.json
+++ b/messages/es.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.main-page.title": "Compare {productsLength} products",
   "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -41,6 +41,7 @@
   "store/product-comparison.main-page.back-to-products": "Back to products list",
   "store/product-comparison.main-page.sort-by": "Sort by",
   "store/product-comparison.main-page.order-added": "Order added",
+  "store/product-comparison.product-summary-row.show-differences": "Show only differences",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.title": "Hide Product Specification Group",
   "admin/editor.comparison-grid.product-specification-groups-to-be-removed.description": "Names of product specification groups which needs to be hidden in comparison page (separate them by comma `,`)"
 }

--- a/react/ComparisonPage.tsx
+++ b/react/ComparisonPage.tsx
@@ -41,6 +41,10 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'store/product-comparison.main-page.order-added',
   },
+  title: {
+    defaultMessage: '',
+    id: 'store/product-comparison.main-page.title',
+  },
 })
 
 const ComparisonPage = ({ children, intl, showToast }: Props) => {
@@ -87,7 +91,9 @@ const ComparisonPage = ({ children, intl, showToast }: Props) => {
         fullWidth
         pageHeader={
           <PageHeader
-            title={`Compare ${comparisonProducts.length} products`}
+            title={intl.formatMessage(messages.title, {
+              productsLength: ` ` + comparisonProducts.length,
+            })}
             linkLabel={intl.formatMessage(messages.backToProducts)}
             onLinkClick={onBackButtonClick}
           >

--- a/react/components/comparisonPageRow/ProductSummaryRow.tsx
+++ b/react/components/comparisonPageRow/ProductSummaryRow.tsx
@@ -5,7 +5,15 @@ import ComparisonContext from '../../ProductComparisonContext'
 import { useCssHandles } from 'vtex.css-handles'
 import { Checkbox } from 'vtex.styleguide'
 import ComparisonProductContext from '../../ComparisonProductContext'
+import { InjectedIntlProps, injectIntl, defineMessages } from 'react-intl'
 import './row.css'
+
+const messages = defineMessages({
+  show_differences: {
+    defaultMessage: '',
+    id: 'store/product-comparison.product-summary-row.show-differences',
+  }
+})
 
 const CSS_HANDLES = [
   'productSummaryRowContainer',
@@ -13,7 +21,7 @@ const CSS_HANDLES = [
   'showDifferencesContainer',
 ]
 
-const ProductSummaryRow = () => {
+const ProductSummaryRow = ({ intl }: InjectedIntlProps) => {
   const cssHandles = useCssHandles(CSS_HANDLES)
 
   const [showDifferences, setShowDifferences] = useState(false)
@@ -65,7 +73,7 @@ const ProductSummaryRow = () => {
             <Checkbox
               checked={showDifferences}
               id={`id-differences`}
-              label="Show only differences"
+              label={intl.formatMessage(messages.show_differences)}
               name={`name-differences`}
               onChange={onSelectorChanged}
               value={showDifferences}
@@ -80,4 +88,4 @@ const ProductSummaryRow = () => {
   )
 }
 
-export default ProductSummaryRow
+export default injectIntl(ProductSummaryRow)


### PR DESCRIPTION
I added in translation two texts from the main page.

- Main page title
- "Show only differences" button


![Screenshot here](https://user-images.githubusercontent.com/43498488/102585956-f6745280-4111-11eb-9490-c10c540b2b47.jpg)

[Workspace here](https://longo--biasicom.myvtex.com/product-comparison)
