### PR TITLE
✨Added pixel event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Added pixel event
 ## [0.5.0] - 2020-11-19
 
 ## [0.4.0] - 2020-11-10

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     "vtex.slider-layout": "0.x",
     "vtex.list-context": "0.x",
     "vtex.product-list-context": "0.x",
-    "vtex.flex-layout": "0.x"
+    "vtex.flex-layout": "0.x",
+    "vtex.pixel-manager": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/__mocks__/vtex.pixel-manager.ts
+++ b/react/__mocks__/vtex.pixel-manager.ts
@@ -1,0 +1,9 @@
+export const PixelContext = {
+  usePixel() {
+    return { push: jest.fn() }
+  },
+}
+
+export const usePixel = () => {
+  return { push: jest.fn() }
+}

--- a/react/components/comparisonPageRow/ProductSummaryRow.tsx
+++ b/react/components/comparisonPageRow/ProductSummaryRow.tsx
@@ -6,6 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { Checkbox } from 'vtex.styleguide'
 import ComparisonProductContext from '../../ComparisonProductContext'
 import './row.css'
+import { usePixel } from 'vtex.pixel-manager'
 
 const CSS_HANDLES = [
   'productSummaryRowContainer',
@@ -36,6 +37,21 @@ const ProductSummaryRow = () => {
   )
   const products = pathOr([] as ProductToCompare[], ['products'], productData)
 
+  const { push } = usePixel()
+
+  const pixelEvent = (products: object, length: number) => {
+    if (!!length && length >= 2) {
+      push({
+        event: 'productComparison',
+        products,
+        compareProductN: length,
+      })
+    }
+  }
+  useEffect(() => {
+    pixelEvent(comparisonData.products, comparisonData.products.length)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   useEffect(() => {
     const showDifferences =
       comparisonData.products &&

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -21,7 +21,7 @@
     "types": ["node", "jest", "graphql"]
   },
   "exclude": ["node_modules"],
-  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts", "__mocks__/vtex.pixel-manager.js"],
   "typeAcquisition": {
     "enable": false
   }


### PR DESCRIPTION
### Added pixel event 
This event is usable through gtm that allows to capture the event of comparison between elements sending as data, productId and skuId products compared and quantity of products.

Integrating the event in the gtm it could be managed as shown in the figure.
![image](https://user-images.githubusercontent.com/73878310/108849340-57247d80-75e2-11eb-957f-e0f5fe0ebdbb.png)

You can try it here [Workspace](https://headeracervelione--itwhirlpoolqa.myvtex.com/)