### PR TITLE
bugfix "allspecifications" Pseudogroup showing up.

### DIFF
--- a/react/components/comparisonFields/GroupedProductSpecifications.tsx
+++ b/react/components/comparisonFields/GroupedProductSpecifications.tsx
@@ -56,6 +56,7 @@ const GroupedProductSpecifications = ({
 
             if (
               groupName !== '' &&
+              groupName !== 'allSpecifications' &&
               !contains(groupName, specificationGroupsToHide) &&
               specifications.length > 0
             ) {


### PR DESCRIPTION
#### What problem is this solving?

The product Context has one Pseudo Group of specifications "allspecifications" that sits along the configured groups. As the name says, it contains ALL specifications again.
The consequence is that in the product comparison table with grouped specifications, any spec listed shows up twice. once in it's corresponding group, and once in the final group "allSpecifications". 

The bugfix just adds the condition to skip the allSpecifications item in rendering, 

#### How to test it?

Bugfix applied here:
https://kaibrockelt--ibksport.myvtex.com/bikes?__bindingAddress=ibksport.eu/
Bug visible here:
https://ibksport.myvtex.com/bikes?__bindingAddress=ibksport.eu/

click the little double arrow on 2 products to start comparison. Move to the product-comparison page by clicking compare. See the big fat table at the end? Yep! That is supposed to go after the bugfix,

[Workspace](Link goes here!)

#### Screenshots or example usage:

![allspecs](https://user-images.githubusercontent.com/93577143/162152268-ce6874d0-0222-41c5-9eff-817ae4b4998b.png)


#### Describe alternatives you've considered, if any.

No alternatives. its a buggy bug.

#### Related to / Depends on

acceptance of a PR. nothing else.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media0.giphy.com/media/CDVPlCA103MTC/giphy.gif?cid=ecf05e47k8b0djsgqgqzkxgsusdmjtgx7p1ufd0t157ji3pf&rid=giphy.gif&ct=g)