### PR TITLE
chore: uses `publicSettingsForApp` endpoint to retrieve app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Uses `publicSettingsForApp` endpoint to retrieve app settings
+
 ## [0.17.0] - 2022-06-15
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,7 @@
     "vtex.product-context": "0.x"
   },
   "settingsSchema": {
+  "access": "public",
     "title": "Product comparison",
     "type": "object",
     "properties": {

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
     "vtex.product-list-context": "0.x",
     "vtex.flex-layout": "0.x",
     "vtex.pixel-manager": "1.x",
-    "vtex.apps-graphql": "2.x",
+    "vtex.apps-graphql": "3.x",
     "vtex.product-context": "0.x"
   },
   "settingsSchema": {

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
     "vtex.product-context": "0.x"
   },
   "settingsSchema": {
-  "access": "public",
+    "access": "public",
     "title": "Product comparison",
     "type": "object",
     "properties": {

--- a/react/ProductComparisonContext.tsx
+++ b/react/ProductComparisonContext.tsx
@@ -212,7 +212,7 @@ const ProductComparisonProvider = ({ children }: Props) => {
 
   useEffect(() => {
     const appSettings = JSON.parse(
-      pathOr(`{}`, ['appSettings', 'message'], appSettingsData)
+      pathOr(`{}`, ['publicSettingsForApp', 'message'], appSettingsData)
     )
 
     dispatch({

--- a/react/queries/AppSettings.graphql
+++ b/react/queries/AppSettings.graphql
@@ -1,5 +1,5 @@
 query AppSettings($version: String) {
-  appSettings(app: "vtex.product-comparison", version: $version)
+  publicSettingsForApp(app: "vtex.product-comparison", version: $version)
     @context(provider: "vtex.apps-graphql") {
     message
   }


### PR DESCRIPTION
This PR uses the [new endpoint at apps-graphql](https://github.com/vtex/apps-graphql/blob/v3.x/graphql/schema.graphql#L46) to retrieve public settings from apps.