### PR TITLE
fix: change appSettings query to server-side

### DIFF
--- a/react/ProductComparisonContext.tsx
+++ b/react/ProductComparisonContext.tsx
@@ -206,8 +206,7 @@ const ProductComparisonProvider = ({ children }: Props) => {
     variables: {
       // eslint-disable-next-line no-undef
       version: process.env.VTEX_APP_VERSION,
-    },
-    ssr: false,
+    }
   })
 
   useEffect(() => {


### PR DESCRIPTION
The query does not should be limited to client-side once the query is now public